### PR TITLE
chore: update server.json version to 0.1.3

### DIFF
--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/atriumn/tokencost-dev",
     "source": "github"
   },
-  "version": "0.1.2",
+  "version": "0.1.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "tokencost-dev",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Change Summary

Update `server.json` version from 0.1.2 to 0.1.3 to match the published npm package and MCP registry entry.

## Risk & Impact Assessment

Risk Level: low

- Version string update only

🤖 Generated with [Claude Code](https://claude.com/claude-code)