### PR TITLE
feat: add createSandboxServer export for registry scanning

### DIFF
--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/atriumn/tokencost-dev",
     "source": "github"
   },
-  "version": "0.1.2",
+  "version": "0.1.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "tokencost-dev",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "transport": {
         "type": "stdio"
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,28 +6,39 @@ import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprot
 import { getModels } from "./pricing.js";
 import { executeTool, tools } from "./tools.js";
 
-const server = new Server(
-  {
-    name: "tokencost-dev",
-    version: "0.1.0",
-  },
-  {
-    capabilities: {
-      tools: {},
+function createServer(): Server {
+  const server = new Server(
+    {
+      name: "tokencost-dev",
+      version: "0.1.0",
     },
-  },
-);
+    {
+      capabilities: {
+        tools: {},
+      },
+    },
+  );
 
-server.setRequestHandler(ListToolsRequestSchema, async () => {
-  return { tools };
-});
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    return { tools };
+  });
 
-server.setRequestHandler(CallToolRequestSchema, async (request) => {
-  const { name, arguments: args } = request.params;
-  return executeTool(name, args);
-});
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
+    return executeTool(name, args);
+  });
+
+  return server;
+}
+
+/** Smithery sandbox: returns a server instance for capability scanning */
+export function createSandboxServer() {
+  return createServer();
+}
 
 async function main() {
+  const server = createServer();
+
   // Pre-warm the cache in background
   getModels().catch(() => {
     // Non-fatal — tools will retry on first call
@@ -38,7 +49,15 @@ async function main() {
   console.error("tokencost MCP server started");
 }
 
-main().catch((error) => {
-  console.error("Failed to start server:", error);
-  process.exit(1);
-});
+// Only start stdio transport when executed directly (not imported for scanning)
+const isDirectExecution =
+  import.meta.url === `file://${process.argv[1]}` ||
+  process.argv[1]?.endsWith("/tokencost-dev") ||
+  process.argv[1]?.endsWith("dist/index.js");
+
+if (isDirectExecution) {
+  main().catch((error) => {
+    console.error("Failed to start server:", error);
+    process.exit(1);
+  });
+}

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -2,7 +2,8 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
+const __dirname =
+  typeof import.meta?.url === "string" ? dirname(fileURLToPath(import.meta.url)) : process.cwd();
 const CACHE_DIR = join(__dirname, "..", ".cache");
 const CACHE_FILE = join(CACHE_DIR, "prices.json");
 const SOURCE_URL =


### PR DESCRIPTION
## Change Summary

Refactor server creation into a factory function and export `createSandboxServer` for MCP registries that scan server capabilities at publish time.

- Extract `createServer()` factory function — no more module-level server singleton
- Export `createSandboxServer()` for registry scanning (Smithery, etc.)
- Guard `main()` so stdio transport only starts on direct execution, not on import
- Make `__dirname` in pricing.ts resilient to CJS bundling (fallback to `process.cwd()`)

## Risk & Impact Assessment

Risk Level: low

- Server behavior is identical when run via `npx tokencost-dev`
- Only affects import-time behavior (new: no side effects on import)
- All 92 tests pass

## Test Plan

- [x] `npx tsc --noEmit` — passes
- [x] `npm run lint` — passes
- [x] `npm run test:run` — 92/92 pass
- [x] `npm run build` — passes
- [x] Smithery CLI scan succeeded (found all 4 tools)

## Manual Verification Steps

1. `npm start` — verify server still starts normally
2. Test with Claude Code to confirm tools work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)