### PR TITLE
Add cryyer for release announcement emails

### DIFF
--- a/.github/workflows/draft-email.yml
+++ b/.github/workflows/draft-email.yml
@@ -1,0 +1,44 @@
+name: Draft Email
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches: [main]
+
+jobs:
+  draft:
+    if: startsWith(github.head_ref, 'release-please--')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - name: Extract version from PR branch
+        id: version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "value=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Generate draft
+        uses: atriumn/cryyer/.github/actions/draft-file@v0
+        id: draft
+        with:
+          product: tokencost
+          version: ${{ steps.version.outputs.value }}
+          llm-provider: gemini
+          llm-model: gemini-3-flash-preview
+          llm-api-key: ${{ secrets.GEMINI_API_KEY }}
+
+      - name: Commit draft
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add drafts/
+          git diff --cached --quiet && exit 0
+          git commit -m "chore: draft email for v${{ steps.version.outputs.value }}"
+          git push

--- a/.github/workflows/send-email.yml
+++ b/.github/workflows/send-email.yml
@@ -1,0 +1,29 @@
+name: Send Email
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  send:
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Extract version
+        id: version
+        run: echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Send email
+        uses: atriumn/cryyer/.github/actions/send-file@v0
+        with:
+          product: tokencost
+          draft-path: drafts/v${{ steps.version.outputs.value }}.md
+          from-email: ${{ secrets.FROM_EMAIL }}
+          email-api-key: ${{ secrets.RESEND_API_KEY }}
+          subscriber-store: gist
+          github-gist-id: ${{ secrets.SUBSCRIBERS_GIST_ID }}
+          github-token: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/products/tokencost.yaml
+++ b/products/tokencost.yaml
@@ -1,0 +1,11 @@
+id: tokencost
+name: tokencost
+repo: atriumn/tokencost-dev
+tagline: LLM Pricing Oracle — real model pricing data via MCP
+voice: >
+  Concise and developer-friendly. Lead with what changed and why it matters.
+  Skip marketing fluff — our audience is technical users who integrate tokencost
+  into their AI workflows. Use plain language, short paragraphs, and bullet points.
+emailSubjectTemplate: "tokencost {{version}} — what's new"
+from_name: tokencost
+reply_to: jeff@atriumn.com


### PR DESCRIPTION
## Summary
- Adds cryyer product config (`products/tokencost.yaml`) with developer-friendly voice
- Adds `draft-email.yml` workflow — generates LLM-drafted emails (Gemini 3 Flash) when release-please opens a PR
- Adds `send-email.yml` workflow — sends emails via Resend on GitHub Release publish, gated by `production` environment approval
- Subscribers stored in a private GitHub Gist

## Setup completed
- `production` GitHub environment created
- Private gist created with initial subscriber (jrojers@gmail.com)
- Repo secrets set: `GEMINI_API_KEY`, `RESEND_API_KEY`, `FROM_EMAIL`, `SUBSCRIBERS_GIST_ID`

## Test plan
- [x] `npx @atriumn/cryyer check` — product config validates
- [x] `npx @atriumn/cryyer draft-file` — generates draft with Gemini 3 Flash
- [x] `npx @atriumn/cryyer send-file --dry-run` — resolves 1 subscriber from gist, previews email
- [ ] Verify `RELEASE_PLEASE_TOKEN` has gist access (needed for send workflow in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)