### PR TITLE
chore(deps): hold TypeScript on 5.x, ignore 6.x line in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,12 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # TypeScript 6.0 is a transitional major (pre-native-TS7) and breaks
+      # ambient Node globals. Hold the 6.x line; TS 7 will still arrive as a
+      # normal Dependabot PR. Revisit 6.x deliberately as a tracked migration.
+      - dependency-name: "typescript"
+        versions: ["6.x"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## What

Adds a Dependabot `ignore` rule holding **TypeScript on the 5.x line** and skipping the **6.x** range.

## Why

TypeScript 6.0 is a transitional major (the release before the native TS 7 / Go port) and changed how ambient Node globals resolve — it broke `process`, `global`, `node:fs`, etc. across our repos (`TS2591`/`TS2304`), failing CI on the auto-bump PRs. It's a **dev-only** dependency, so there's no runtime or security reason to chase it now.

## Notification on TS 7

We ignore only `versions: ["6.x"]`, **not** all majors — so when TypeScript 7 ships, Dependabot will open a normal PR for it automatically. We stay informed; we just stop the 6.x noise.

When we do want TS 6 (or 7), we take it on deliberately as a tracked migration rather than via auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/atriumn/codesmith/tokencost-dev/pr/57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783872730&installation_id=139490959&pr_number=57&repository=atriumn%2Ftokencost-dev&return_to=https%3A%2F%2Fgithub.com%2Fatriumn%2Ftokencost-dev%2Fpull%2F57&signature=5fd0964496b2790c0a6bb3c0aa817999812161c4b7c5c1d2c09d9dd25a6a81f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->