### PR TITLE
fix(search): guard empty query in fuzzyMatch

### DIFF
--- a/src/search.ts
+++ b/src/search.ts
@@ -73,6 +73,13 @@ export function fuzzyMatch(query: string, models: Record<string, ModelEntry>): M
   const withoutProvider = stripProviderPrefix(query);
   const { base: normalizedQuery } = extractFineTunedBase(withoutProvider);
 
+  // An empty/whitespace query has no meaningful match. Newer fuse.js versions
+  // return results for an empty pattern, so guard explicitly rather than relying
+  // on Fuse to return empty.
+  if (normalizedQuery.trim() === "") {
+    return null;
+  }
+
   // Try exact match first
   if (models[normalizedQuery]) {
     return models[normalizedQuery];


### PR DESCRIPTION
## What

`fuzzyMatch("", models)` should return `null`, but newer `fuse.js` versions return matches for an empty pattern instead of an empty result set. This broke the dependabot minor-patch bump (#59), where the test `returns null for empty string against populated models` started failing.

## Fix

Guard an empty/whitespace query at the top of `fuzzyMatch` and return `null` directly, rather than relying on Fuse's empty-pattern behavior.

## Why this way

Defensive and version-independent — correct regardless of which fuse.js version is installed. Unblocks the pending dependabot dependency bump once rebased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/atriumn/codesmith/tokencost-dev/pr/60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785426051&installation_id=139490959&pr_number=60&repository=atriumn%2Ftokencost-dev&return_to=https%3A%2F%2Fgithub.com%2Fatriumn%2Ftokencost-dev%2Fpull%2F60&signature=9cef1fae48378d0858025693190eab8d4ebcbe6d3f66b4d3d2c842f8bbbd90a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->